### PR TITLE
feat: show one departure per transport type (up to 3)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -156,25 +156,33 @@ export default function Home() {
     return `${hours}h ${minutes}m`;
   };
 
-  // Combine all departures into a single sorted list
+  // One soonest departure per transport type, up to 3 types, sorted by departure time
   const getAllDepartures = (): DepartureWithStation[] => {
     const allDepartures: DepartureWithStation[] = [];
-    
+
     selectedStops.forEach(stop => {
-      const stopDepartures = departures[stop.id] || [];
-      stopDepartures.forEach(departure => {
-        allDepartures.push({
-          ...departure,
-          stationName: stop.name
-        });
+      (departures[stop.id] || []).forEach(departure => {
+        allDepartures.push({ ...departure, stationName: stop.name });
       });
     });
 
-    return allDepartures.sort((a, b) => {
+    allDepartures.sort((a, b) => {
       const timeA = a.when ? new Date(a.when).getTime() : Infinity;
       const timeB = b.when ? new Date(b.when).getTime() : Infinity;
       return timeA - timeB;
     });
+
+    const seen = new Set<string>();
+    const result: DepartureWithStation[] = [];
+    for (const d of allDepartures) {
+      const key = d.type.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(d);
+        if (result.length === 3) break;
+      }
+    }
+    return result;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Instead of listing every departure sorted by time, the board now picks the **earliest departure for each distinct transport type** (bus, subway, tram, regional rail, ferry, …)
- At most **3 transport types** are shown, ordered by which type departs soonest
- This gives a quick at-a-glance view — one slot per mode — rather than flooding the list with 10 buses in a row

## Example

Before: bus in 2 min, bus in 4 min, bus in 7 min, subway in 9 min, tram in 12 min  
After: bus in 2 min · subway in 9 min · tram in 12 min

## Test plan

- [ ] Pick a busy stop (e.g. Alexanderplatz) — verify only 3 cards shown, one per mode
- [ ] Pick a single-mode stop (e.g. a U-Bahn-only stop) — verify only 1 card shown
- [ ] Verify live polling still refreshes the cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)