### PR TITLE
fix: one departure per line (110, U3, S1), up to 3

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -156,7 +156,7 @@ export default function Home() {
     return `${hours}h ${minutes}m`;
   };
 
-  // One soonest departure per transport type, up to 3 types, sorted by departure time
+  // One soonest departure per line (110, U3, S1 …), up to 3 lines, sorted by departure time
   const getAllDepartures = (): DepartureWithStation[] => {
     const allDepartures: DepartureWithStation[] = [];
 
@@ -175,7 +175,7 @@ export default function Home() {
     const seen = new Set<string>();
     const result: DepartureWithStation[] = [];
     for (const d of allDepartures) {
-      const key = d.type.toLowerCase();
+      const key = d.line;
       if (!seen.has(key)) {
         seen.add(key);
         result.push(d);


### PR DESCRIPTION
## Summary

- Groups by exact line name (110, U3, S1 …) instead of transport type
- Shows the soonest departure per line, up to 3 lines, ordered by departure time

Reverts the type-based grouping from #8 and replaces it with the intended line-based grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)